### PR TITLE
use version number instead of release in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
     - ARCH="i686"
     - ARCH="x86_64"
 julia:
-  - release
+  - 0.4
   - nightly
 matrix:
   exclude:


### PR DESCRIPTION
release will change over time, but your REQUIRE file says this package supports julia 0.4 so it should continue to be tested