### PR TITLE
option to delete all values, `Base.drop` deprecation, avoid `Pkg.dir`

### DIFF
--- a/src/LMDB.jl
+++ b/src/LMDB.jl
@@ -4,7 +4,11 @@ module LMDB
     isdefined(:Docile) && eval(:(@document))
 
     import Base: open, close, getindex, setindex!, put!, start, reset,
-                 isopen, count, delete!, drop, info, get, show
+                 isopen, count, delete!, info, get, show
+
+    if VERSION < v"0.6.0"
+        import Base: drop
+    end
 
     depsfile = Pkg.dir("LMDB","deps","deps.jl")
     if isfile(depsfile)

--- a/src/LMDB.jl
+++ b/src/LMDB.jl
@@ -13,6 +13,8 @@ module LMDB
         error("LMDB not properly installed. Please run Pkg.build(\"LMDB\")")
     end
 
+    depsfile = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
+
     export Environment, create, open, close, sync, set!, unset!, getindex, setindex!, path, info, show,
            Transaction, start, abort, commit, reset, renew, environment,
            DBI, drop, delete!, get, put!,

--- a/src/LMDB.jl
+++ b/src/LMDB.jl
@@ -10,7 +10,7 @@ module LMDB
         import Base: drop
     end
 
-    depsfile = Pkg.dir("LMDB","deps","deps.jl")
+    depsfile = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
     if isfile(depsfile)
         include(depsfile)
     else

--- a/src/LMDB.jl
+++ b/src/LMDB.jl
@@ -7,13 +7,12 @@ module LMDB
                  isopen, count, delete!, info, get, show, convert
     import Base.Iterators: drop
 
+    depsfile = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
     if isfile(depsfile)
         include(depsfile)
     else
         error("LMDB not properly installed. Please run Pkg.build(\"LMDB\")")
     end
-
-    depsfile = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
 
     export Environment, create, open, close, sync, set!, unset!, getindex, setindex!, path, info, show,
            Transaction, start, abort, commit, reset, renew, environment,

--- a/src/dbi.jl
+++ b/src/dbi.jl
@@ -80,9 +80,9 @@ function put!(txn::Transaction, dbi::DBI, key, val; flags::Cuint=zero(Cuint))
 end
 
 "Delete items from a database"
-function delete!(txn::Transaction, dbi::DBI, key, val)
+function delete!(txn::Transaction, dbi::DBI, key, val=C_NULL)
     mdb_key_ref = Ref(MDBValue(key))
-    mdb_val_ref = Ref(MDBValue(val))
+    mdb_val_ref = (val === C_NULL) ? C_NULL : Ref(MDBValue(val))
 
     ret = ccall((:mdb_del, liblmdb), Cint,
                 (Ptr{Void}, Cuint, Ptr{MDBValue}, Ptr{MDBValue}),

--- a/test/dbi.jl
+++ b/test/dbi.jl
@@ -38,6 +38,7 @@ module LMDB_DBI
                     value = get(txn, dbi, k, AbstractString)
                     println("Got value for key $(k): $(value)")
                     @test value == val*string(k)
+                    delete!(txn, dbi, k)
                     k += 1
                     value = get(txn, dbi, k, AbstractString)
                     println("Got value for key $(k): $(value)")


### PR DESCRIPTION
- Allow delete of all values for a key when no `val` is supplied to the `delete!` method. This is done by passing a `C_NULL` as value (as in the C API doc).
- handle deprecation of `Base.drop` by importing it only in Julia `v0.5`
- use `dirname` instead of `Pkg.dir` to make it compatible to loading via `LOADPATH`