### PR TITLE
improve MDBValue type handling

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.6
 BinDeps
+UnalignedVectors

--- a/src/LMDB.jl
+++ b/src/LMDB.jl
@@ -20,7 +20,7 @@ module LMDB
            DBI, drop, delete!, get, put!,
            Cursor, count, transaction, database,
            isflagset, isopen,
-           LMDBError, CursorOps
+           LMDBError, CursorOps, LMDBPath
 
     include("common.jl")
     include("env.jl")

--- a/src/LMDB.jl
+++ b/src/LMDB.jl
@@ -1,5 +1,6 @@
 __precompile__(true)
 module LMDB
+    using UnalignedVectors
 
     isdefined(:Docile) && eval(:(@document))
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -126,3 +126,8 @@ Base.show(io::IO, err::LMDBError) = print(io, "Code[$(err.code)]: $(err.msg)")
 
 """ Check if binary flag is set in provided value"""
 isflagset(value, flag) = (value & flag) == flag
+
+"""LMDB path"""
+immutable LMDBPath
+    path::String
+end

--- a/src/cur.jl
+++ b/src/cur.jl
@@ -65,6 +65,7 @@ end
 
 This function retrieves key/data pairs from the database.
 """
+get{K<:Number,T}(cur::Cursor, key::K, ::Type{T}) = get(cur, [key], T)
 function get{T}(cur::Cursor, key, ::Type{T}, op::CursorOps=FIRST)
     # Setup parameters
     mdb_key_ref = Ref(MDBValue(key))
@@ -85,6 +86,12 @@ end
 This function stores key/data pairs into the database. The cursor is positioned at the new item, or on failure usually near it.
 """
 function put!(cur::Cursor, key, val; flags::Cuint = zero(Cuint))
+    if isa(key, Number) || isa(val, Number)
+        key = isa(key, Number) ? [key] : key
+        val = isa(val, Number) ? [val] : val
+        return put!(cur, key, val; flags=flags)
+    end
+
     mdb_key_ref = Ref(MDBValue(key))
     mdb_val_ref = Ref(MDBValue(val))
 

--- a/src/cur.jl
+++ b/src/cur.jl
@@ -65,8 +65,8 @@ end
 
 This function retrieves key/data pairs from the database.
 """
-get{K<:Number,T}(cur::Cursor, key::K, ::Type{T}) = get(cur, [key], T)
-function get{T}(cur::Cursor, key, ::Type{T}, op::CursorOps=FIRST)
+get{K,T}(cur::Cursor, key::K, ::Type{T}, op::CursorOps=FIRST) = get(cur, [key], T)
+function get{K<:Union{String,Array},T}(cur::Cursor, key::K, ::Type{T}, op::CursorOps=FIRST)
     # Setup parameters
     mdb_key_ref = Ref(MDBValue(key))
     mdb_val_ref = Ref(MDBValue())
@@ -86,9 +86,9 @@ end
 This function stores key/data pairs into the database. The cursor is positioned at the new item, or on failure usually near it.
 """
 function put!(cur::Cursor, key, val; flags::Cuint = zero(Cuint))
-    if isa(key, Number) || isa(val, Number)
-        key = isa(key, Number) ? [key] : key
-        val = isa(val, Number) ? [val] : val
+    if !ismdbvalue(key) || !ismdbvalue(val)
+        key = ismdbvalue(key) ? key : [key]
+        val = ismdbvalue(val) ? val : [val]
         return put!(cur, key, val; flags=flags)
     end
 

--- a/src/dbi.jl
+++ b/src/dbi.jl
@@ -68,9 +68,9 @@ end
 
 "Store items into a database"
 function put!(txn::Transaction, dbi::DBI, key, val; flags::Cuint = zero(Cuint))
-    if isa(key, Number) || isa(val, Number)
-        key = isa(key, Number) ? [key] : key
-        val = isa(val, Number) ? [val] : val
+    if !ismdbvalue(key) || !ismdbvalue(val)
+        key = ismdbvalue(key) ? key : [key]
+        val = ismdbvalue(val) ? val : [val]
         return put!(txn, dbi, key, val; flags=flags)
     end
 
@@ -87,9 +87,9 @@ end
 
 "Delete items from a database"
 function delete!(txn::Transaction, dbi::DBI, key, val=C_NULL)
-    if isa(key, Number) || isa(val, Number)
-        key = isa(key, Number) ? [key] : key
-        val = isa(val, Number) ? [val] : val
+    if !ismdbvalue(key) || !ismdbvalue(val)
+        key = ismdbvalue(key) ? key : [key]
+        val = ismdbvalue(val) ? val : [val]
         return delete!(txn, dbi, key, val)
     end
 
@@ -105,8 +105,8 @@ function delete!(txn::Transaction, dbi::DBI, key, val=C_NULL)
 end
 
 "Get items from a database. Returned values are safe to access as long as the transaction is not closed."
-get{K<:Number,T}(txn::Transaction, dbi::DBI, key::K, ::Type{T}) = get(txn, dbi, [key], T)
-function get{T}(txn::Transaction, dbi::DBI, key, ::Type{T})
+get{K,T}(txn::Transaction, dbi::DBI, key::K, ::Type{T}) = get(txn, dbi, [key], T)
+function get{K<:Union{String,Array},T}(txn::Transaction, dbi::DBI, key::K, ::Type{T})
     # Setup parameters
     mdb_key_ref = Ref(MDBValue(key))
     mdb_val_ref = Ref(MDBValue())

--- a/src/env.jl
+++ b/src/env.jl
@@ -52,7 +52,8 @@ function open(env::Environment, path::String; flags::Cuint=zero(Cuint), mode::Cm
 end
 
 "Wrapper of `open` for `do` construct"
-function open(f::Function, path::String; flags::Cuint=zero(Cuint), mode::Cmode_t = 0o755)
+function open(f::Function, lmpath::LMDBPath; flags::Cuint=zero(Cuint), mode::Cmode_t = 0o755)
+    path = lmpath.path
     env = create()
     try
         open(env, path)

--- a/test/common.jl
+++ b/test/common.jl
@@ -19,7 +19,7 @@ module LMDB_Common
     val = [1233]
     T = eltype(val)
     val_size = sizeof(val)
-    mdb_val = MDBValue(val[1])
+    mdb_val = MDBValue(val)
     @test val_size == mdb_val.size
     nvals = floor(Int, mdb_val.size/sizeof(T))
     value = unsafe_wrap(Array, convert(Ptr{T}, mdb_val.data), nvals)

--- a/test/cur.jl
+++ b/test/cur.jl
@@ -34,7 +34,7 @@ module LMDB_CUR
     @test !isopen(env)
 
     # Block style
-    open(dbname) do env # open environment
+    open(LMDBPath(dbname)) do env # open environment
         start(env) do txn # start transaction
             open(txn) do dbi # open database
                 open(txn, dbi) do cur # open cursor

--- a/test/dbi.jl
+++ b/test/dbi.jl
@@ -15,6 +15,7 @@ module LMDB_DBI
             ,110                => "key value is 10"
             ,211                => [MyType(10,true), MyType(11,false)]
             ,210                => [11, 12, 13]
+            ,212                => MyType(12,true)
         ]
         ,[
             "311-str"          => 11
@@ -22,6 +23,9 @@ module LMDB_DBI
         ]
         ,[
             MyType(10, true)   => MyType(11, false)
+        ]
+        ,[
+            [MyType(10, true)]   => MyType(11, false)
         ]
     ]
 

--- a/test/env.jl
+++ b/test/env.jl
@@ -10,6 +10,9 @@ module LMDB_Env
     @test env[:Readers] == 126
     @test env[:KeySize] == 511
     @test env[:Flags] == 0
+    @test path(env) == ""
+
+    show(STDOUT, env)
 
     # Manipulate flags
     @test !isflagset(env[:Flags], Cuint(LMDB.NOSYNC))
@@ -30,9 +33,12 @@ module LMDB_Env
         ret = open(env, dbname)
         @test ret[1] == 0
 
+        @show env
+
         # Close environment
         close(env)
         @test !isopen(env)
+        @test_throws LMDBError close(env)
 
         # do block
         create() do env


### PR DESCRIPTION
- prevent possible invalid ptr for `Number` types by holding a reference utill `ccall` returns (fixes #12)
- allow using any immutable bits types to be used in keys and values (fixes #13)
- added some test cases