### PR TITLE
fixes for 0.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+deps/deps.jl

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.6
 BinDeps
-Nullables
 Compat

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,4 @@
 julia 0.6
 BinDeps
+Nullables
+Compat

--- a/src/LMDB.jl
+++ b/src/LMDB.jl
@@ -1,7 +1,7 @@
 __precompile__(true)
 module LMDB
 
-    using Nullables, Compat
+    using Compat
 
     if VERSION.minor < 7
         isdefined(:Docile) && eval(:(@document))

--- a/src/LMDB.jl
+++ b/src/LMDB.jl
@@ -1,7 +1,13 @@
 __precompile__(true)
 module LMDB
 
-    isdefined(:Docile) && eval(:(@document))
+    using Nullables, Compat
+
+    if VERSION.minor < 7
+        isdefined(:Docile) && eval(:(@document))
+    else
+        eval(:(@isdefined(Docile) && eval(:(@document))))
+    end
 
     import Base: open, close, getindex, setindex!, put!, start, reset,
                  isopen, count, delete!, info, get, show, convert, show

--- a/src/common.jl
+++ b/src/common.jl
@@ -3,11 +3,11 @@ const Cmode_t = Cushort
 "Generic structure used for passing keys and data in and out of the database."
 struct MDBValue
     size::Csize_t   # size of the data item
-    data::Ptr{Void} # address of the data item
+    data::Ptr{Nothing} # address of the data item
 end
 
 MDBValue() = MDBValue(zero(Csize_t), C_NULL)
-MDBValue(_::Void) = MDBValue()
+MDBValue(_::Nothing) = MDBValue()
 MDBValue(val::String) = MDBValue(sizeof(val), pointer(val))
 function MDBValue(val::T) where {T}
     isbits(T) && error("Can not wrap a $T in MDBValue. Use a $T array instead")
@@ -15,15 +15,15 @@ function MDBValue(val::T) where {T}
     return MDBValue(val_size, pointer(val))
 end
 
-convert{T}(::Type{T}, mdb_val_ref::Ref{MDBValue}) = _convert(T, mdb_val_ref[])
+convert(::Type{T}, mdb_val_ref::Ref{MDBValue}) where {T} = _convert(T, mdb_val_ref[])
 function _convert(::Type{String}, mdb_val::MDBValue)
     unsafe_string(convert(Ptr{UInt8}, mdb_val.data), mdb_val.size)
 end
-function _convert{T}(::Type{Vector{T}}, mdb_val::MDBValue)
+function _convert(::Type{Vector{T}}, mdb_val::MDBValue) where {T}
     res = unsafe_wrap(Array, convert(Ptr{UInt8}, mdb_val.data), mdb_val.size)
     reinterpret(T,res)
 end
-function _convert{T}(::Type{T}, mdb_val::MDBValue)
+function _convert(::Type{T}, mdb_val::MDBValue) where {T}
     unsafe_load(convert(Ptr{T}, mdb_val.data))
 end
 

--- a/src/cur.jl
+++ b/src/cur.jl
@@ -2,8 +2,8 @@
 A handle to a cursor structure for navigating through a database.
 """
 mutable struct Cursor
-    handle::Ptr{Void}
-    Cursor(cur::Ptr{Void}) = new(cur)
+    handle::Ptr{Nothing}
+    Cursor(cur::Ptr{Nothing}) = new(cur)
 end
 
 "Check if cursor is open"
@@ -11,9 +11,9 @@ isopen(cur::Cursor) = cur.handle != C_NULL
 
 "Create a cursor"
 function open(txn::Transaction, dbi::DBI)
-    cur_ptr_ref = Ref{Ptr{Void}}(C_NULL)
+    cur_ptr_ref = Ref{Ptr{Nothing}}(C_NULL)
     ret = ccall((:mdb_cursor_open, liblmdb), Cint,
-                 (Ptr{Void}, Cuint, Ptr{Ptr{Void}}),
+                 (Ptr{Nothing}, Cuint, Ptr{Ptr{Nothing}}),
                   txn.handle, dbi.handle, cur_ptr_ref)
     (ret != 0) && throw(LMDBError(ret))
     return Cursor(cur_ptr_ref[])
@@ -34,7 +34,7 @@ function close(cur::Cursor)
     if cur.handle == C_NULL
         warn("Cursor is already closed")
     end
-    ccall((:mdb_cursor_close, liblmdb), Void, (Ptr{Void},), cur.handle)
+    ccall((:mdb_cursor_close, liblmdb), Nothing, (Ptr{Nothing},), cur.handle)
     cur.handle = C_NULL
     return
 end
@@ -42,21 +42,21 @@ end
 "Renew a cursor"
 function renew(txn::Transaction, cur::Cursor)
     ret = ccall((:mdb_cursor_renew, liblmdb), Cint,
-                 (Ptr{Void}, Ptr{Void}), txn.handle, cur.handle)
+                 (Ptr{Nothing}, Ptr{Nothing}), txn.handle, cur.handle)
     (ret != 0) && throw(LMDBError(ret))
     return ret
 end
 
 "Return the cursor's transaction"
 function transaction(cur::Cursor)
-    txn_ptr = ccall((:mdb_cursor_txn, liblmdb), Ptr{Void}, (Ptr{Void},), cur.handle)
+    txn_ptr = ccall((:mdb_cursor_txn, liblmdb), Ptr{Nothing}, (Ptr{Nothing},), cur.handle)
     (txn_ptr == C_NULL) && return nothing
     return Transaction(txn_ptr)
 end
 
 "Return the cursor's database"
 function database(cur::Cursor)
-    dbi = ccall((:mdb_cursor_dbi, liblmdb), Cuint, (Ptr{Void},), cur.handle)
+    dbi = ccall((:mdb_cursor_dbi, liblmdb), Cuint, (Ptr{Nothing},), cur.handle)
     (dbi == 0) && return nothing
     return DBI(dbi, "")
 end
@@ -73,7 +73,7 @@ function get(cur::Cursor, key, ::Type{T}, op::CursorOps=SET_KEY) where T
 
     # Get value
     ret = ccall( (:mdb_cursor_get, liblmdb), Cint,
-                  (Ptr{Void}, Ptr{MDBValue}, Ptr{MDBValue}, Cint),
+                  (Ptr{Nothing}, Ptr{MDBValue}, Ptr{MDBValue}, Cint),
                    cur.handle, mdb_key_ref, mdb_val_ref, Cint(op))
     (ret != 0) && throw(LMDBError(ret))
 
@@ -92,7 +92,7 @@ function put!(cur::Cursor, key, val; flags::Cuint = zero(Cuint))
     mdb_val_ref = Ref(MDBValue(v))
 
     ret = ccall((:mdb_cursor_put, liblmdb), Cint,
-                 (Ptr{Void}, Ptr{MDBValue}, Ptr{MDBValue}, Cuint),
+                 (Ptr{Nothing}, Ptr{MDBValue}, Ptr{MDBValue}, Cuint),
                   cur.handle, mdb_key_ref, mdb_val_ref, flags)
 
     (ret != 0) && throw(LMDBError(ret))
@@ -102,7 +102,7 @@ end
 "Delete current key/data pair to which the cursor refers"
 function delete!(cur::Cursor; flags::Cuint = zero(Cuint))
     ret = ccall((:mdb_cursor_del, liblmdb), Cint,
-                 (Ptr{Void}, Cuint), cur.handle, flags)
+                 (Ptr{Nothing}, Cuint), cur.handle, flags)
     (ret != 0) && throw(LMDBError(ret))
     return ret
 end
@@ -111,7 +111,7 @@ end
 function count(cur::Cursor)
     countp = Csize_t[0]
     ret = ccall( (:mdb_cursor_count, liblmdb), Cint,
-                  (Ptr{Void}, Csize_t), cur.handle, countp)
+                  (Ptr{Nothing}, Csize_t), cur.handle, countp)
     (ret != 0) && throw(LMDBError(ret))
     return Int(countp[1])
 end

--- a/src/dbi.jl
+++ b/src/dbi.jl
@@ -15,7 +15,7 @@ function open(txn::Transaction, dbname::String = ""; flags::Cuint = zero(Cuint))
     cdbname = length(dbname) > 0 ? dbname : convert(Cstring, Ptr{UInt8}(C_NULL))
     handle = Cuint[0]
     ret = ccall((:mdb_dbi_open, liblmdb), Cint,
-                (Ptr{Void}, Cstring, Cuint, Ptr{Cuint}),
+                (Ptr{Nothing}, Cstring, Cuint, Ptr{Cuint}),
                  txn.handle, cdbname, flags, handle)
     (ret != 0) && throw(LMDBError(ret))
     return DBI(handle[1], dbname)
@@ -37,7 +37,7 @@ function close(env::Environment, dbi::DBI)
     if !isopen(env)
         warn("Environment is closed")
     end
-    ccall((:mdb_dbi_close, liblmdb), Void, (Ptr{Void}, Cuint), env.handle, dbi.handle)
+    ccall((:mdb_dbi_close, liblmdb), Nothing, (Ptr{Nothing}, Cuint), env.handle, dbi.handle)
     dbi.handle = zero(Cuint)
     return
 end
@@ -46,7 +46,7 @@ end
 function flags(txn::Transaction, dbi::DBI)
     flags = Cuint[0]
     ret = ccall((:mdb_dbi_flags, liblmdb), Cint,
-                (Ptr{Void}, Cuint, Ptr{Cuint}),
+                (Ptr{Nothing}, Cuint, Ptr{Cuint}),
                  txn.handle, dbi.handle, flags)
     (ret != 0) && throw(LMDBError(ret))
     return flags[1]
@@ -60,7 +60,7 @@ DB will be deleted from the environment and DB handle will be closed
 function drop(txn::Transaction, dbi::DBI; delete = false)
     del = delete ? Int32(1) : Int32(0)
     ret = ccall((:mdb_drop, liblmdb), Cint,
-                (Ptr{Void}, Cuint, Cint),
+                (Ptr{Nothing}, Cuint, Cint),
                  txn.handle, dbi.handle, del)
     (ret != 0) && throw(LMDBError(ret))
     return ret
@@ -74,7 +74,7 @@ function put!(txn::Transaction, dbi::DBI, key, val; flags::Cuint = zero(Cuint))
     mdb_val_ref = Ref(MDBValue(v))
 
     ret = ccall((:mdb_put, liblmdb), Cint,
-                (Ptr{Void}, Cuint, Ptr{MDBValue}, Ptr{MDBValue}, Cuint),
+                (Ptr{Nothing}, Cuint, Ptr{MDBValue}, Ptr{MDBValue}, Cuint),
                 txn.handle, dbi.handle, mdb_key_ref, mdb_val_ref, flags)
 
     (ret != 0) && throw(LMDBError(ret))
@@ -89,7 +89,7 @@ function delete!(txn::Transaction, dbi::DBI, key, val=C_NULL)
     mdb_val_ref = Ref((val === C_NULL) ? MDBValue() : MDBValue(v))
 
     ret = ccall((:mdb_del, liblmdb), Cint,
-                (Ptr{Void}, Cuint, Ptr{MDBValue}, Ptr{MDBValue}),
+                (Ptr{Nothing}, Cuint, Ptr{MDBValue}, Ptr{MDBValue}),
                 txn.handle, dbi.handle, mdb_key_ref, mdb_val_ref)
 
     (ret != 0) && throw(LMDBError(ret))
@@ -105,7 +105,7 @@ function get(txn::Transaction, dbi::DBI, key, ::Type{T}) where T
 
     # Get value
     ret = ccall((:mdb_get, liblmdb), Cint,
-                 (Ptr{Void}, Cuint, Ptr{MDBValue}, Ptr{MDBValue}),
+                 (Ptr{Nothing}, Cuint, Ptr{MDBValue}, Ptr{MDBValue}),
                  txn.handle, dbi.handle, mdb_key_ref, mdb_val_ref)
     (ret != 0) && throw(LMDBError(ret))
 

--- a/src/txn.jl
+++ b/src/txn.jl
@@ -3,13 +3,13 @@ A database transaction. Every operation requires a transaction handle.
 All database operations require a transaction handle. Transactions may be read-only or read-write.
 """
 mutable struct Transaction
-    handle::Ptr{Void}
+    handle::Ptr{Nothing}
     Transaction() = new(C_NULL)
-    Transaction(h::Ptr{Void}) = new(h)
+    Transaction(h::Ptr{Nothing}) = new(h)
 end
 
 function env(txn::Transaction)
-    env_ptr = ccall((:mdb_txn_env, liblmdb), Ptr{Void}, (Ptr{Void},), txn.handle)
+    env_ptr = ccall((:mdb_txn_env, liblmdb), Ptr{Nothing}, (Ptr{Nothing},), txn.handle)
     (env_ptr == C_NULL) && return nothing
     return Environment(env_ptr)
 end
@@ -24,9 +24,9 @@ It allows to set transaction flags with `flags` option.
 """
 function start(env::Environment; flags::Cuint=zero(Cuint),
                parent::Nullable{Transaction} = Nullable{Transaction}())
-    txn_ref = Ref{Ptr{Void}}(C_NULL)
+    txn_ref = Ref{Ptr{Nothing}}(C_NULL)
     ret = ccall( (:mdb_txn_begin, liblmdb), Cint,
-                  (Ptr{Void}, Ptr{Void}, Cuint, Ptr{Ptr{Void}}),
+                  (Ptr{Nothing}, Ptr{Nothing}, Cuint, Ptr{Ptr{Nothing}}),
                    env.handle, get(parent, Transaction()).handle,  flags, txn_ref)
     (ret != 0) && throw(LMDBError(ret))
     return Transaction(txn_ref[])
@@ -39,7 +39,7 @@ start(f::Function, env::Environment; flags::EnvironmentFlags=EMPTY) = f(start(en
 The transaction and its cursors must not be used after, because its handle is freed.
 """
 function abort(txn::Transaction)
-    ccall( (:mdb_txn_abort, liblmdb), Void, (Ptr{Void},), txn.handle)
+    ccall( (:mdb_txn_abort, liblmdb), Nothing, (Ptr{Nothing},), txn.handle)
     txn.handle = C_NULL
     return
 end
@@ -49,7 +49,7 @@ end
 The transaction and its cursors must not be used after, because its handle is freed.
 """
 function commit(txn::Transaction)
-    ret = ccall( (:mdb_txn_commit, liblmdb), Cint, (Ptr{Void},), txn.handle)
+    ret = ccall( (:mdb_txn_commit, liblmdb), Cint, (Ptr{Nothing},), txn.handle)
     txn.handle = C_NULL
     (ret != 0) && throw(LMDBError(ret))
     return ret
@@ -60,7 +60,7 @@ end
 Abort the transaction like `abort`, but keep the transaction handle.
 """
 function reset(txn::Transaction)
-    ret = ccall( (:mdb_txn_reset, liblmdb), Cint, (Ptr{Void},), txn.handle)
+    ret = ccall( (:mdb_txn_reset, liblmdb), Cint, (Ptr{Nothing},), txn.handle)
     (ret != 0) && throw(LMDBError(ret))
     return ret
 end
@@ -71,7 +71,7 @@ This acquires a new reader lock for a transaction handle that had been released 
 It must be called before a reset transaction may be used again.
 """
 function renew(txn::Transaction)
-    ret = ccall( (:mdb_txn_renew, liblmdb), Cint, (Ptr{Void},), txn.handle)
+    ret = ccall( (:mdb_txn_renew, liblmdb), Cint, (Ptr{Nothing},), txn.handle)
     (ret != 0) && throw(LMDBError(ret))
     return ret
 end

--- a/src/txn.jl
+++ b/src/txn.jl
@@ -23,11 +23,11 @@ isopen(txn::Transaction) = txn.handle != C_NULL
 It allows to set transaction flags with `flags` option.
 """
 function start(env::Environment; flags::Cuint=zero(Cuint),
-               parent::Nullable{Transaction} = Nullable{Transaction}())
+               parent::Union{Transaction,Nothing} = nothing)
     txn_ref = Ref{Ptr{Nothing}}(C_NULL)
     ret = ccall( (:mdb_txn_begin, liblmdb), Cint,
                   (Ptr{Nothing}, Ptr{Nothing}, Cuint, Ptr{Ptr{Nothing}}),
-                   env.handle, get(parent, Transaction()).handle,  flags, txn_ref)
+                   env.handle, parent != nothing ? parent.handle : Transaction().handle,  flags, txn_ref)
     (ret != 0) && throw(LMDBError(ret))
     return Transaction(txn_ref[])
 end

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,6 +1,11 @@
 module LMDB_Common
     using LMDB
-    using Base.Test
+    if VERSION.minor < 7
+        using Base.Test
+    else
+        using Test
+    end
+
     import LMDB.MDBValue
 
     @test LMDB.version()[1] >= v"0.9.15"

--- a/test/cur.jl
+++ b/test/cur.jl
@@ -1,6 +1,10 @@
 module LMDB_CUR
     using LMDB
-    using Base.Test
+    if VERSION.minor < 7
+        using Base.Test
+    else
+        using Test
+    end
 
     const dbname = "testdb"
     key = 10

--- a/test/dbi.jl
+++ b/test/dbi.jl
@@ -1,6 +1,11 @@
 module LMDB_DBI
     using LMDB
-    using Base.Test
+    if VERSION.minor < 7
+        using Base.Test
+    else
+        using Test
+    end
+
 
     const dbname = "testdb"
     key = 10

--- a/test/env.jl
+++ b/test/env.jl
@@ -1,6 +1,10 @@
 module LMDB_Env
     using LMDB
-    using Base.Test
+    if VERSION.minor < 7
+        using Base.Test
+    else
+        using Test
+    end
 
     const dbname = "testdb"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,5 @@
-if VERSION.minor < 7
-    using Base.Test
-else
-    using Test
-end
+using Compat
+using Compat.Test
 push!(LOAD_PATH, joinpath(dirname(@__FILE__), "../src"))
 
 @testset "LMDB" for t in ["common", "env", "dbi", "cur"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,9 @@
-using Base.Test
+if VERSION.minor < 7
+    using Base.Test
+else
+    using Test
+end
+push!(LOAD_PATH, joinpath(dirname(@__FILE__), "../src"))
 
 @testset "LMDB" for t in ["common", "env", "dbi", "cur"]
     fp = "$t.jl"


### PR DESCRIPTION
Using `Compat` and version checks around `using Test` and `@isdefined` makes the tests pass on both 0.7 and 0.6.