### PR TITLE
Don't extend `Base.convert`; instead, define a separate `mbd_unpack` function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LMDB"
 uuid = "11f193de-5e89-5f17-923a-7d207d56daf9"
 authors = ["Art Wild <wildart@gmail.com>"]
-version = "0.2.1"
+version = "1.0.0-DEV"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/LMDB.jl
+++ b/src/LMDB.jl
@@ -3,7 +3,7 @@ module LMDB
     @isdefined(Docile) && eval(:(@document))
 
     import Base: open, close, getindex, setindex!, put!, reset,
-                 isopen, count, delete!, keys, get, show, convert, show
+                 isopen, count, delete!, keys, get, show, show
     import Base.Iterators: drop
 
     export Environment, create, open, close, sync, set!, unset!, getindex, setindex!, path, info, show,

--- a/src/common.jl
+++ b/src/common.jl
@@ -9,15 +9,15 @@ function MDBValue(val::T) where {T}
     return MDB_val(Csize_t(val_size), convert(Ptr{Cvoid},pointer(val)))
 end
 
-convert(::Type{T}, mdb_val_ref::Ref{MDB_val}) where {T} = _convert(T, mdb_val_ref[])
-function _convert(::Type{String}, mdb_val::MDB_val)
+mbd_unpack(::Type{T}, mdb_val_ref::Ref{MDB_val}) where {T} = _mbd_unpack(T, mdb_val_ref[])
+function _mbd_unpack(::Type{T}, mdb_val::MDB_val) where {T <: String}
     unsafe_string(convert(Ptr{UInt8}, mdb_val.mv_data), mdb_val.mv_size)
 end
-function _convert(::Type{Vector{T}}, mdb_val::MDB_val) where {T}
+function _mbd_unpack(::Type{V}, mdb_val::MDB_val) where {T, V <: Vector{T}}
     res = unsafe_wrap(Array, convert(Ptr{UInt8}, mdb_val.mv_data), mdb_val.mv_size)
-    reinterpret(T,res)
+    reinterpret(T, res)
 end
-function _convert(::Type{T}, mdb_val::MDB_val) where {T}
+function _mbd_unpack(::Type{T}, mdb_val::MDB_val) where {T}
     unsafe_load(convert(Ptr{T}, mdb_val.mv_data))
 end
 

--- a/src/dbi.jl
+++ b/src/dbi.jl
@@ -83,5 +83,5 @@ function get(txn::Transaction, dbi::DBI, key, ::Type{T}) where T
     mdb_get(txn.handle, dbi.handle, mdb_key_ref, mdb_val_ref)
 
     # Convert to proper type
-    return convert(T, mdb_val_ref)
+    return mbd_unpack(T, mdb_val_ref)
 end

--- a/src/dicts.jl
+++ b/src/dicts.jl
@@ -10,7 +10,7 @@ mutable struct LMDBDict{K,V}
         x
     end
 end
-function LMDBDict{K,V}(path::String; readonly = false, rdahead=false) where {K,V} 
+function LMDBDict{K,V}(path::String; readonly = false, rdahead=false) where {K,V}
     flags = readonly ? MDB_RDONLY : zero(Cuint)
     if !rdahead
         flags = flags | MDB_NORDAHEAD
@@ -110,7 +110,7 @@ function Base.get(d::LMDBDict{K,V}, key, default) where {K,V}
         if ret == MDB_NOTFOUND
             return default
         elseif ret == Cint(0)
-            return convert(V, mdb_val_ref)
+            return mbd_unpack(V, mdb_val_ref)
         else
             throw(LMDB.LMDBError(ret))
         end

--- a/test/common.jl
+++ b/test/common.jl
@@ -14,7 +14,7 @@ using Test
     mdb_val_ref = Ref(MDBValue(val));
     mdb_val = mdb_val_ref[]
     # @test val == unsafe_string(convert(Ptr{UInt8}, mdb_val.data), mdb_val.size)
-    @test val == convert(String, mdb_val_ref)
+    @test val == LMDB.mbd_unpack(String, mdb_val_ref)
 
     val = [1233] # dense array
     T = eltype(val)
@@ -25,7 +25,7 @@ using Test
     nvals = floor(Int, mdb_val.mv_size/sizeof(T))
     value = unsafe_wrap(Array, convert(Ptr{T}, mdb_val.mv_data), nvals)
     @test val == value
-    @test val == convert(Vector{Int}, mdb_val_ref)
+    @test val == LMDB.mbd_unpack(Vector{Int}, mdb_val_ref)
 
     val = [0x0003, 0xff45]
     val_size = sizeof(val)
@@ -36,7 +36,7 @@ using Test
     nvals = floor(Int, mdb_val.mv_size/sizeof(T))
     value = unsafe_wrap(Array, convert(Ptr{T}, mdb_val.mv_data), nvals)
     @test val == value
-    @test val == convert(Vector{UInt16}, mdb_val_ref)
+    @test val == LMDB.mbd_unpack(Vector{UInt16}, mdb_val_ref)
 
     struct TestType
         i::Int
@@ -53,5 +53,5 @@ using Test
     nvals = floor(Int, mdb_val.mv_size/sizeof(T))
     value = unsafe_wrap(Array, convert(Ptr{T}, mdb_val.mv_data), nvals)
     @test val == value
-    @test val == convert(Vector{T}, mdb_val_ref)
-    @test val[1] == convert(T, mdb_val_ref)
+    @test val == LMDB.mbd_unpack(Vector{T}, mdb_val_ref)
+    @test val[1] == LMDB.mbd_unpack(T, mdb_val_ref)


### PR DESCRIPTION
Fixes #29

In https://github.com/wildart/LMDB.jl/issues/29#issuecomment-1021493204, @meggart mentioned that this would be a breaking change. Therefore, I have bumped the version number in the `Project.toml` file from 0.2.1 to 1.0.0-DEV to reflect the breaking change.