### PR TITLE
Log a warning if the environment is already closed

### DIFF
--- a/src/env.jl
+++ b/src/env.jl
@@ -60,7 +60,7 @@ end
 """Close the environment and release the memory map"""
 function close(env::Environment)
     if env.handle == C_NULL
-        throw(LMDBError(-1,"Environment is already closed"))
+        @warn "Environment is already closed" handle=env.handle path=env.path
     end
     _mdb_env_close(env.handle)
     env.handle = C_NULL


### PR DESCRIPTION
This change prevents errors when a Julia session is closed and finalizers are called. If application code has already closed an environment, the result is a noisy error which may interfere with uncalled finalizers:

```
[N] caleb@caleb-thinkpad ~> julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.11.3 (2025-01-21)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> using LMDB

julia> d = LMDBDict{String, String}(mktempdir())
LMDBDict{String, String}(Environment is opened
DB path: /tmp/jl_VAhwKQ
Size of the data memory map: 1048576
ID of the last used page: 1
ID of the last committed transaction: 0
Max reader slots in the environment: 126
Max reader slots used in the environment: 0, DBI(0x00000001, ""))

julia> close(d)
0

julia> # Ctrl-d to close Julia session
┌ Warning: Environment is closed
└ @ LMDB ~/.julia/packages/LMDB/4tVoz/src/dbi.jl:34
error in running finalizer: MethodError(f=LMDB.LMDBError, args=(-1, "Environment is already closed"), world=0x0000000000006884)
jl_method_error_bare at /cache/build/builder-demeter6-3/julialang/julia-release-1-dot-11/src/gf.c:2254
jl_method_error at /cache/build/builder-demeter6-3/julialang/julia-release-1-dot-11/src/gf.c:2272
jl_lookup_generic_ at /cache/build/builder-demeter6-3/julialang/julia-release-1-dot-11/src/gf.c:3106 [inlined]
ijl_apply_generic at /cache/build/builder-demeter6-3/julialang/julia-release-1-dot-11/src/gf.c:3121
close at /home/caleb/.julia/packages/LMDB/4tVoz/src/env.jl:63 [inlined]
#16 at /home/caleb/.julia/packages/LMDB/4tVoz/src/dicts.jl:8
unknown function (ip: 0x7f42a4322082)
run_finalizer at /cache/build/builder-demeter6-3/julialang/julia-release-1-dot-11/src/gc.c:299
jl_gc_run_finalizers_in_list at /cache/build/builder-demeter6-3/julialang/julia-release-1-dot-11/src/gc.c:389
run_finalizers at /cache/build/builder-demeter6-3/julialang/julia-release-1-dot-11/src/gc.c:435
ijl_atexit_hook at /cache/build/builder-demeter6-3/julialang/julia-release-1-dot-11/src/init.c:299
jl_repl_entrypoint at /cache/build/builder-demeter6-3/julialang/julia-release-1-dot-11/src/jlapi.c:1060
main at /cache/build/builder-demeter6-3/julialang/julia-release-1-dot-11/cli/loader_exe.c:58
unknown function (ip: 0x7f42d3686e07)
__libc_start_main at /usr/lib/libc.so.6 (unknown line)
unknown function (ip: 0x4010b8)
[I] caleb@caleb-thinkpad ~>
```
